### PR TITLE
Return `cache_status` with data

### DIFF
--- a/shcache.lua
+++ b/shcache.lua
@@ -237,7 +237,7 @@ local function _return(self, data, flags)
 
    self.cache_status = cache_status
 
-   return data, self.from_cache
+   return data, self.from_cache, cache_status
 end
 
 local function _set(self, ...)


### PR DESCRIPTION
This is needed to validate `STALE` data.

@hostinger/devops